### PR TITLE
Restore default SIGPIPE handler after fork()

### DIFF
--- a/mqtt-exec.c
+++ b/mqtt-exec.c
@@ -34,6 +34,11 @@ void message_cb(struct mosquitto *mosq, void *obj,
 	struct userdata *ud = (struct userdata *)obj;
 	if (msg->payloadlen || ud->verbose) {
 		if (ud->command_argv && fork() == 0) {
+			/* mosquitto ignores SIGPIPE, this is a problem as it
+			 * gets inherited by all processes spawned by mqtt-exec
+			 * restore the default handler explicitly for now. */
+			signal(SIGPIPE, SIG_DFL);
+
 			if (ud->verbose)
 				ud->command_argv[ud->command_argc-2] = msg->topic;
 			ud->command_argv[ud->command_argc-1] =


### PR DESCRIPTION
The MQTT mosquitto library ignores SIGPIPE on purpose to "prevent
unnecessary client quits in threaded mode":

* https://github.com/eclipse/mosquitto/blob/d5970ca9985f4d3193fe7a359707723090bb13e9/lib/mosquitto.c#L112-L114
* https://github.com/eclipse/mosquitto/blob/d5970ca9985f4d3193fe7a359707723090bb13e9/src/mosquitto.c#L413

However, the default handler should be available to child processes
spawned by mqtt-exec. Hence, we reset it after fork(). Otherwise, this
causes issues when running test suites in Alpine.

See https://gitlab.alpinelinux.org/alpine/aports/-/issues/13573